### PR TITLE
Fix RV32IM asm examples parsing

### DIFF
--- a/asmde/allocator.py
+++ b/asmde/allocator.py
@@ -278,7 +278,7 @@ class SpecialRegFile(RegFile):
         if not tag in self.special_pool:
             self.special_pool[tag] = PhysicalRegister(tag, self.description.reg_class)
         return self.special_pool[tag]
-        
+
 class RegFileDescription:
     """ descriptor of a register file object """
     def __init__(self, reg_class, num_phys_reg, reg_ctor, virtual_reg_ctor, reg_file_class=RegFile, isAllocatable=lambda self, index: True):
@@ -361,7 +361,8 @@ class BasicBlock:
     def fallback(self):
         """ basic block fall backs to the next one if it does not end with
             a non-conditional jump """
-        return (not self.bundle_list[-1].has_nocond_jump) or self.bundle_list[-1].has_cond_jump
+        return not self.bundle_list or \
+                (not self.bundle_list[-1].has_nocond_jump) or self.bundle_list[-1].has_cond_jump
 
     def add_bundle(self, bundle):
         self.bundle_list.append(bundle)
@@ -388,7 +389,7 @@ class BasicBlock:
         assert (self.bundle_list == [] or merged_bb.bundle_list == [])
         self.bundle_list = self.bundle_list or merged_bb.bundle_list
         if not (self.index is None or merged_bb.index is None):
-            print("[WARNING] duplicate index for bb {}/{} in BasicBlock.merge_in".format(self, merged_bb)) 
+            print("[WARNING] duplicate index for bb {}/{} in BasicBlock.merge_in".format(self, merged_bb))
         self.index = self.index or merged_bb.index
 
     def dump(self, arch, color_map):
@@ -747,7 +748,7 @@ class RegisterAssignator:
                         reg = regObj.baseReg
                         if not reg in liverange_map:
                             liverange_map[reg] = []
-                        if not(len(liverange_map[reg]) and liverange_map[reg][-1].start == (bb_index, index)): 
+                        if not(len(liverange_map[reg]) and liverange_map[reg][-1].start == (bb_index, index)):
                             # only register a liverange once per index value
                             liverange_map[reg].append(LiveRange(start=(bb_index, index), start_dbg_object=insn.dbg_object))
             # closing BB's LiveRange by iterating over var_out
@@ -874,7 +875,7 @@ class RegisterAssignator:
                     color_map[linked_reg] = linked_color
                     # check on colour bound
                     if linked_color >= num_reg_in_class:
-                        print("Error while assigning register of class {}, requesting index {}, only {} register(s) available".format(reg_class.name, linked_color, num_reg_in_class)) 
+                        print("Error while assigning register of class {}, requesting index {}, only {} register(s) available".format(reg_class.name, linked_color, num_reg_in_class))
                         raise Exception()
 
                     if verbose: print("register {} of class {} has been assigned color {}".format(linked_reg, reg_class.name, linked_color))

--- a/asmde/allocator.py
+++ b/asmde/allocator.py
@@ -361,8 +361,7 @@ class BasicBlock:
     def fallback(self):
         """ basic block fall backs to the next one if it does not end with
             a non-conditional jump """
-        return not self.bundle_list or \
-                (not self.bundle_list[-1].has_nocond_jump) or self.bundle_list[-1].has_cond_jump
+        return (not self.bundle_list[-1].has_nocond_jump) or self.bundle_list[-1].has_cond_jump
 
     def add_bundle(self, bundle):
         self.bundle_list.append(bundle)

--- a/asmde/asm_stats.py
+++ b/asmde/asm_stats.py
@@ -75,7 +75,8 @@ if __name__ == "__main__":
     for input_name in args.input:
         print("parsing input program {}".format(input_name))
         program = Program()
-        asm_parser = AsmParser(args.arch, program)
+        arch = args.arch()
+        asm_parser = AsmParser(arch, program)
         with open(input_name, "r") as input_stream:
             # TODO/FIXME: optimize file reading (line by line rather than full file at once)
             full_input_file = input_stream.read()
@@ -114,7 +115,7 @@ if __name__ == "__main__":
             # finish program (e.g. connecting last BB to sink)
             asm_parser.program.end_program()
 
-        program_stats = ProgramStatistics(args.arch, input_name)
+        program_stats = ProgramStatistics(arch, input_name)
         program_stats.analyse_program(program, args.verbose_pattern)
         program_stats.fuse_in(stats, exhaustive_opc=args.display_all_opcodes)
 

--- a/asmde/parser.py
+++ b/asmde/parser.py
@@ -47,7 +47,7 @@ def MetaPopOperatorPredicate(op_value):
     def predicate(lexem_list):
         lexem = lexem_list[0]
         if not isinstance(lexem, OperatorLexem) or lexem.value != op_value:
-            # raise Exception(" expecting operator {}, got {}".format(op_value, lexem)) 
+            # raise Exception(" expecting operator {}, got {}".format(op_value, lexem))
             return None
         return lexem_list[1:]
     return predicate
@@ -107,7 +107,7 @@ class VirtualRegisterPattern(Pattern):
 class VirtualRegisterPattern_Any(VirtualRegisterPattern):
     @classmethod
     def get_reg_list_from_names(VRP_Class, arch, reg_name_list, reg_type):
-        
+
        # REG_CLASS_PATTERN_MAP = {
        #     "R": VirtualRegisterPattern_Std,
        #     "A": VirtualRegisterPattern_Acc,
@@ -297,7 +297,7 @@ class GenericOffsetPattern(Pattern):
             print("unrecognized lexem {} while parsing for offset".format(offset_lexem))
             raise NotImplementedError
         return offset, lexem_list
-    
+
 
 class OffsetPattern_Std(GenericOffsetPattern):
     """ pattern for address offset """
@@ -346,7 +346,7 @@ class OpcodePattern(Pattern):
                 predicate = lexem_list[1].value
                 opcode = "{}.{}".format(opcode, predicate)
                 lexem_list = lexem_list[2:]
-            
+
             return opcode, lexem_list
 
 class LabelPattern(Pattern):
@@ -515,6 +515,7 @@ class AsmParser:
         if not len(lexem_list): return
         head = lexem_list[0]
         if isinstance(head, BundleSeparatorLexem):
+            assert self.arch.hasBundle()
             self.program.add_bundle(self.ongoing_bundle)
             self.ongoing_bundle = Bundle()
         elif isinstance(head, MacroLexem):
@@ -544,7 +545,7 @@ class AsmParser:
                 # skipping "Dissasembly of section ..."
                 pass
             elif len(lexem_list) > 1 and isinstance(lexem_list[1], LabelEndLexem):
-                if len(self.ongoing_bundle) != 0:
+                if len(self.ongoing_bundle) != 0 and self.arch.hasBundle():
                     print("Error: label can not be inserted in the middle of a bundle @ {}".format(dbg_object))
                     sys.exit(1)
                 self.program.add_label(head.value)
@@ -575,7 +576,8 @@ class AsmParser:
                     succ.add_predecessor(self.program.current_bb)
                 # in objdump file, a instruction line may be ended by a bundle separator
                 #   goto label;;
-                if len(lexem_list) and isinstance(lexem_list[-1], BundleSeparatorLexem):
+                if len(lexem_list) and isinstance(lexem_list[-1], BundleSeparatorLexem) or \
+                        not self.arch.hasBundle():
                     self.program.add_bundle(self.ongoing_bundle)
                     self.ongoing_bundle = Bundle()
 


### PR DESCRIPTION
This patch fixes the following examples:
```
./examples/riscv/test_rv32_0.S
./examples/riscv/test_rv32_1.S
./examples/riscv/test_rv32_m.S
```

These are still failing:

```
./examples/riscv/test_rv32_f.S
./examples/riscv/test_rv32_vadd.S
```